### PR TITLE
Add TaggedPDF and GenerateOutline to PageSettings

### DIFF
--- a/ChromiumHtmlToPdfLib/Browser.cs
+++ b/ChromiumHtmlToPdfLib/Browser.cs
@@ -655,6 +655,8 @@ internal class Browser : IDisposable, IAsyncDisposable
             message.AddParameter("footerTemplate", pageSettings.FooterTemplate);
         message.AddParameter("preferCSSPageSize", pageSettings.PreferCSSPageSize);
         message.AddParameter("transferMode", "ReturnAsStream");
+        message.AddParameter("generateTaggedPDF", pageSettings.TaggedPDF);
+        message.AddParameter("generateDocumentOutline", pageSettings.GenerateOutline);
 
         var result = countdownTimer == null
             ? await _pageConnection.SendForResponseAsync(message, cancellationToken).ConfigureAwait(false)

--- a/ChromiumHtmlToPdfLib/Settings/PageSettings.cs
+++ b/ChromiumHtmlToPdfLib/Settings/PageSettings.cs
@@ -122,6 +122,17 @@ public class PageSettings : ICloneable
     ///     The paper format
     /// </summary>
     public PaperFormat PaperFormat { get; private set; }
+
+    /// <summary>
+    ///     Generate tagged PDF. Defaults to true.
+    /// </summary>
+    public bool TaggedPDF { get; set; } = true;
+
+    /// <summary>
+    ///     Generate outline bookmarks from header tags (H1-H6). Defaults to false.
+    ///     Requires both <see cref="Converter.UseOldHeadlessMode"/> and <see cref="TaggedPDF"/> set to <c>true</c>.
+    /// </summary>
+    public bool GenerateOutline { get; set; }
     #endregion
 
     #region PageSettings
@@ -167,6 +178,8 @@ public class PageSettings : ICloneable
         MarginLeft = 0.4;
         MarginRight = 0.4;
         PageRanges = string.Empty;
+        TaggedPDF = true;
+        GenerateOutline = false;
     }
     #endregion
 
@@ -271,7 +284,9 @@ public class PageSettings : ICloneable
             MarginRight = MarginRight,
             PageRanges = PageRanges,
             IgnoreInvalidPageRanges = IgnoreInvalidPageRanges,
-            PreferCSSPageSize = PreferCSSPageSize
+            PreferCSSPageSize = PreferCSSPageSize,
+            TaggedPDF = TaggedPDF,
+            GenerateOutline = GenerateOutline
         };
     }
     #endregion


### PR DESCRIPTION
Adds option to enable outlines (bookmarks) generation from `<h1-6>` header tags (same feature exists in `wkhtmltopdf`).

As this feature was added to chromium just recently, looks like it doesn't work yet in all scenarios and require following configuration:
- `Converter.UseOldHeadlessMode` must be `true`
- `Page.printToPDF` parameter `generateDocumentOutline` must be `true`
- `Page.printToPDF` parameter `generateTaggedPDF` must be `true` (as tagged data used for outlines generation). This is enabled by default, but I've added configuration for it to `PageSettings` anyways

(nor `Converter.UseOldHeadlessMode=false` nor `--generate-pdf-document-outline` works with Chromium 122 when used with `Page.printToPDF` currently)

https://issues.chromium.org/issues/41387522

https://chromium-review.googlesource.com/c/chromium/src/+/5026474

