### PR TITLE
Specify "=old" on the headless argument.

### DIFF
--- a/ChromiumHtmlToPdfLib/Converter.cs
+++ b/ChromiumHtmlToPdfLib/Converter.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Converter.cs
 //
 // Author: Kees van Spelde <sicos2002@hotmail.com>
@@ -555,7 +555,7 @@ public class Converter : IDisposable, IAsyncDisposable
             for (var i = 0; i < _defaultChromiumArgument.Count; i++)
             {
                 if (!_defaultChromiumArgument[i].StartsWith("--headless")) continue;
-                _defaultChromiumArgument[i] = value ? "--headless" : "--headless=new";
+                _defaultChromiumArgument[i] = value ? "--headless=old" : "--headless=new";
                 return;
             }
         }


### PR DESCRIPTION
"--headless" by default is sometimes "old". However, this year (2024), Google will be looking to make the default "new". Likely this rollout has already happened. This will mess with the program when ran on older servers, I guess (Windows Server 2019 Datacenter). I'm unsure how the compatibility works exactly... Nevertheless, I've been having "Google Chrome exited unexpectedly" errors until I added the "=old" specification. Source explaining the default value change: https://developer.chrome.com/docs/chromium/new-headless#use_headless_mode.