### PR TITLE
Removing Utf.Unknown dependency, using StreamReader check instead

### DIFF
--- a/ChromiumHtmlToPdfLib/ChromiumHtmlToPdfLib.csproj
+++ b/ChromiumHtmlToPdfLib/ChromiumHtmlToPdfLib.csproj
@@ -42,7 +42,6 @@
     </PackageReference>
     <PackageReference Include="Svg" Version="3.4.7" />
     <PackageReference Include="System.Runtime.Caching" Version="9.0.0" />
-    <PackageReference Include="UTF.Unknown" Version="2.5.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR is to remove the Utf.Unknown package dependency by replacing the one-line file encoding check with a call to StreamReader. The StreamReader will read up to 1024 bytes of the file with the, and then use StreamReader.CurrentEncoding to determine the file encoding. This should work fine, but I have no idea how to test it. Thoughts?