### PR TITLE
Add several options useful for running on linux server for internal projects

### DIFF
--- a/ChromiumHtmlToPdfConsole/Options.cs
+++ b/ChromiumHtmlToPdfConsole/Options.cs
@@ -431,5 +431,23 @@ public class Options
     /// </remarks>
     [Option("enable-chromium-logging", Required = false, HelpText = "Enables Chromium logging; The output will be saved to the file chrome_debug.log in Chrome's user data directory. Logs are overwritten each time you restart Chromium")]
     public bool EnableChromiumLogging { get; set; }
+
+    /// <summary>
+    ///     Passes --disable-gpu to Chromium. This should be useful on common server hardware.
+    /// </summary>
+    [Option("disable-gpu", Required = false, HelpText = "Disables GPU hardware acceleration.")]
+    public bool DisableGpu { get; set; }
+
+    /// <summary>
+    ///     Passes --ignore-certificate-errors to Chromium. Useful when generating from internal web server.
+    /// </summary>
+    [Option("ignore-certificate-errors", Required = false, HelpText = "Ignores certificate-related errors.")]
+    public bool IgnoreCertificateErrors { get; set; }
+
+    /// <summary>
+    ///     Passes --disable-crash-reporter and --no-crashpad to Chromium.
+    /// </summary>
+    [Option("disable-crash-reporter", Required = false, HelpText = "Passes --disable-crash-reporter and --no-crashpad to Chromium.")]
+    public bool DisableCrashReporter { get; set; }
     #endregion
 }

--- a/ChromiumHtmlToPdfConsole/Program.cs
+++ b/ChromiumHtmlToPdfConsole/Program.cs
@@ -329,6 +329,18 @@ static class Program
 
         if (options.EnableChromiumLogging)
             converter.EnableChromiumLogging = true;
+
+        if (options.DisableGpu)
+            converter.AddChromiumArgument("--disable-gpu");
+
+        if (options.IgnoreCertificateErrors)
+            converter.AddChromiumArgument("--ignore-certificate-errors");
+
+        if (options.DisableCrashReporter)
+        {
+            converter.AddChromiumArgument("--disable-crash-reporter");
+            converter.AddChromiumArgument("--no-crashpad");
+        }
     }
     #endregion
 


### PR DESCRIPTION
All options are passed to Chromium.

* --disable-gpu - useful GPU is not available on regular server hardware.
* --ignore-certificate-errors - publicly signed certificates are not obtainable for internal domains, e.g. web apps running in Docker.
* --disable-crash-reporter - this is a quite recent issue, it seems that the directory still must exist and be writable, but this option should prevent it from taking up more space (see https://github.com/chrome-php/chrome/issues/649#issuecomment-2336592370)