### PR TITLE
Don't suppress exception from SendForResponseAsync

### DIFF
--- a/ChromiumHtmlToPdfLib/Connection.cs
+++ b/ChromiumHtmlToPdfLib/Connection.cs
@@ -270,18 +270,18 @@ public class Connection : IDisposable, IAsyncDisposable
             await _webSocket.SendAsync(MessageToBytes(message), WebSocketMessageType.Text, true, linkedCts.Token).ConfigureAwait(false);
 
             tcs.Task.Wait(cancellationToken);
-            return cancellationToken.IsCancellationRequested ? string.Empty : tcs.Task.Result;
+
+            return tcs.Task.Result;
         }
         catch (Exception exception)
         {
             WebSocketOnError(_logger, new ErrorEventArgs(exception));
+            throw;
         }
         finally
         {
             MessageReceived -= receivedHandler;
         }
-
-        return string.Empty;
     }
     #endregion
 

--- a/ChromiumHtmlToPdfLib/Connection.cs
+++ b/ChromiumHtmlToPdfLib/Connection.cs
@@ -273,7 +273,7 @@ public class Connection : IDisposable, IAsyncDisposable
 
             return tcs.Task.Result;
         }
-        catch (Exception exception)
+        catch (Exception exception) when (exception is not (TaskCanceledException or OperationCanceledException))
         {
             WebSocketOnError(_logger, new ErrorEventArgs(exception));
             throw;


### PR DESCRIPTION
I'm not sure why old code suppressed exception and returned empty string - it doesn't look like it will help, as caller will fail on respose parsing from empty string, which I actually observed for cancelled request:

1. chrome request aborted by cancellation token:

![image](https://github.com/user-attachments/assets/95c83b87-0b74-4e7b-af4e-7c766b50875c)

2. because exception was suppressed, caller also fails trying to access response object

![image](https://github.com/user-attachments/assets/96978db5-f248-4f88-95e4-02ba54e5c311)
