### PR TITLE
Comprehensive Header and Footer Customization

### DIFF
--- a/ChromiumHtmlToPdfConsole/Options.cs
+++ b/ChromiumHtmlToPdfConsole/Options.cs
@@ -81,6 +81,51 @@ public class Options
     public bool DisplayHeaderFooter { get; set; }
 
     /// <summary>
+    ///     HTML template for the print header.
+    /// </summary>
+
+    [Option("header-template", Required = false , HelpText = "HTML template for the print header.")]
+    public string? HeaderTemplate { get; set; }
+
+    /// <summary>
+    ///     HTML template for the print header.
+    /// </summary>
+
+    [Option("footer-template", Required = false, HelpText = "HTML template for the print footer.")]
+    public string? FooterTemplate { get; set; }
+
+    [Option("header-left", HelpText = "Text to print in the left corner of the header.")]
+    public string? HeaderLeft { get; set; }
+
+    [Option("header-center", HelpText = "Text to print in the center of the header.")]
+    public string? HeaderCenter { get; set; }
+
+    [Option("header-right", HelpText = "Text to print in the right corner of the header.")]
+    public string? HeaderRight { get; set; }
+
+    [Option("header-font-name", HelpText = "The font name to use for the header.")]
+    public string? HeaderFontName { get; set; }
+
+    [Option("header-font-size", HelpText = "The font size (in pt) to use for the header.")]
+    public double? HeaderFontSize { get; set; }
+
+    [Option("footer-left", HelpText = "Text to print in the left corner of the footer.")]
+    public string? FooterLeft { get; set; }
+
+    [Option("footer-center", HelpText = "Text to print in the center of the footer.")]
+    public string? FooterCenter { get; set; }
+
+    [Option("footer-right", HelpText = "Text to print in the right corner of the footer.")]
+    public string? FooterRight { get; set; }
+
+    [Option("footer-font-name", HelpText = "The font name to use for the footer.")]
+    public string? FooterFontName { get; set; }
+
+    [Option("footer-font-size", HelpText = "The font size (in pt) to use for the footer.")]
+    public double? FooterFontSize { get; set; }
+
+
+    /// <summary>
     ///     Print background graphics. Defaults to false.
     /// </summary>
     [Option("print-background", Required = false, Default = false, HelpText = "Print background graphics")]

--- a/ChromiumHtmlToPdfConsole/Options.cs
+++ b/ChromiumHtmlToPdfConsole/Options.cs
@@ -83,47 +83,74 @@ public class Options
     /// <summary>
     ///     HTML template for the print header.
     /// </summary>
-
     [Option("header-template", Required = false , HelpText = "HTML template for the print header.")]
     public string? HeaderTemplate { get; set; }
 
     /// <summary>
-    ///     HTML template for the print header.
+    ///      HTML template for the print footer.
     /// </summary>
-
     [Option("footer-template", Required = false, HelpText = "HTML template for the print footer.")]
     public string? FooterTemplate { get; set; }
 
+    /// <summary>
+    ///     Text to print in the left corner of the header.
+    /// </summary>
     [Option("header-left", HelpText = "Text to print in the left corner of the header.")]
     public string? HeaderLeft { get; set; }
 
+    /// <summary>
+    ///     Text to print in the center of the header.
+    /// </summary>
     [Option("header-center", HelpText = "Text to print in the center of the header.")]
     public string? HeaderCenter { get; set; }
 
+    /// <summary>
+    ///     Text to print in the right corner of the header.
+    /// </summary>
     [Option("header-right", HelpText = "Text to print in the right corner of the header.")]
     public string? HeaderRight { get; set; }
 
+    /// <summary>
+    ///     The font name to use for the header.
+    /// </summary>
     [Option("header-font-name", HelpText = "The font name to use for the header.")]
     public string? HeaderFontName { get; set; }
 
+    /// <summary>
+    ///     The font size (in pt) to use for the header.
+    /// </summary
     [Option("header-font-size", HelpText = "The font size (in pt) to use for the header.")]
     public double? HeaderFontSize { get; set; }
 
+    /// <summary>
+    ///     Text to print in the left corner of the footer.
+    /// </summary>
     [Option("footer-left", HelpText = "Text to print in the left corner of the footer.")]
     public string? FooterLeft { get; set; }
 
+    /// <summary>
+    ///     Text to print in the center of the footer.
+    /// </summary>
     [Option("footer-center", HelpText = "Text to print in the center of the footer.")]
     public string? FooterCenter { get; set; }
 
+    /// <summary>
+    ///     Text to print in the right corner of the footer.
+    /// </summary>
     [Option("footer-right", HelpText = "Text to print in the right corner of the footer.")]
     public string? FooterRight { get; set; }
 
+    /// <summary>
+    ///     The font name to use for the footer.
+    /// </summary>
     [Option("footer-font-name", HelpText = "The font name to use for the footer.")]
     public string? FooterFontName { get; set; }
 
+    /// <summary>
+    ///     The font size (in pt) to use for the footer.
+    /// </summary>
     [Option("footer-font-size", HelpText = "The font size (in pt) to use for the footer.")]
     public double? FooterFontSize { get; set; }
-
 
     /// <summary>
     ///     Print background graphics. Defaults to false.
@@ -199,7 +226,7 @@ public class Options
     /// <summary>
     ///     Bottom margin in inches. Defaults to 1cm (~0.4 inches).
     /// </summary>
-    [Option("margin-bottom", Default = 0.4, Required = false, HelpText = "Top margin in inches")]
+    [Option("margin-bottom", Default = 0.4, Required = false, HelpText = "Bottom margin in inches")]
     public double MarginBottom { get; set; }
 
     /// <summary>

--- a/ChromiumHtmlToPdfConsole/Program.cs
+++ b/ChromiumHtmlToPdfConsole/Program.cs
@@ -226,8 +226,94 @@ static class Program
         pageSettings.MarginRight = options.MarginRight;
         pageSettings.PageRanges = options.PageRanges;
 
+        const string blankTemplate = "<div></div>";
+
+        if (!string.IsNullOrEmpty(options.HeaderTemplate))
+        {
+            pageSettings.HeaderTemplate = options.HeaderTemplate;
+        }
+        else
+        {
+            var builtTemplate = BuildTemplate(options.HeaderLeft, options.HeaderCenter, options.HeaderRight, options.HeaderFontName, options.HeaderFontSize);
+            if (builtTemplate != null)
+            {
+                pageSettings.HeaderTemplate = builtTemplate;
+            }
+            else if (options.DisplayHeaderFooter)
+            {
+                pageSettings.HeaderTemplate = blankTemplate;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(options.FooterTemplate))
+        {
+            pageSettings.FooterTemplate = options.FooterTemplate;
+        }
+        else
+        {
+            var builtTemplate = BuildTemplate(options.FooterLeft, options.FooterCenter, options.FooterRight, options.FooterFontName, options.FooterFontSize);
+            if (builtTemplate != null)
+            {
+                pageSettings.FooterTemplate = builtTemplate;
+            }
+            else if (options.DisplayHeaderFooter)
+            {
+                pageSettings.FooterTemplate = blankTemplate;
+            }
+        }
+
         return pageSettings;
     }
+    #endregion
+
+    #region BuildTemplate
+    private static string? BuildTemplate(string? left, string? center, string? right, string? fontName, double? fontSize)
+    {
+        if(string.IsNullOrEmpty(left) && string.IsNullOrEmpty(center) && string.IsNullOrEmpty(right))
+        {
+            return null;
+        }
+
+        var style = new StringBuilder();
+        if (!string.IsNullOrEmpty(fontName))
+        {
+            style.Append($"font-family: {fontName}; ");
+        }
+
+        var finalFontSize = fontSize.HasValue ? $"{fontSize.Value}pt" : "9pt";
+
+        style.Append($"font-size: {finalFontSize};");
+
+        var leftHtml = string.IsNullOrEmpty(left) ? "" : left
+            .Replace("[page]", "<span class='pageNumber'></span>")
+            .Replace("[topage]", "<span class='totalPages'></span>")
+            .Replace("[doctitle]", "<span class='title'></span>")
+            .Replace("[date]", "<span class='date'></span>")
+            .Replace("[url]", "<span class='url'></span>");
+
+        var centerHtml = string.IsNullOrEmpty(center) ? "" : center
+            .Replace("[page]", "<span class='pageNumber'></span>")
+            .Replace("[topage]", "<span class='totalPages'></span>")
+            .Replace("[doctitle]", "<span class='title'></span>")
+            .Replace("[date]", "<span class='date'></span>")
+            .Replace("[url]", "<span class='url'></span>");
+
+        var rightHtml = string.IsNullOrEmpty(right) ? "" : right
+            .Replace("[page]", "<span class='pageNumber'></span>")
+            .Replace("[topage]", "<span class='totalPages'></span>")
+            .Replace("[doctitle]", "<span class='title'></span>")
+            .Replace("[date]", "<span class='date'></span>")
+            .Replace("[url]", "<span class='url'></span>");
+
+        var template = new StringBuilder($"<div style='width: 100%; {style}'><table style='width: 100%;'><tbody><tr>");
+        template.Append($"<td style='width: 33%; text-align: left;'>{leftHtml}</td>");
+        template.Append($"<td style='width: 34%; text-align: center;'>{centerHtml}</td>");
+        template.Append($"<td style='width: 33%; text-align: right;'>{rightHtml}</td>");
+        template.Append("</tr></tbody></table></div>");
+
+        return template.ToString();
+    }
+
     #endregion
 
     #region SetMaxConcurrencyLevel

--- a/ChromiumHtmlToPdfConsole/Program.cs
+++ b/ChromiumHtmlToPdfConsole/Program.cs
@@ -267,9 +267,20 @@ static class Program
     #endregion
 
     #region BuildTemplate
+    /// <summary>
+    /// Builds the HTML template for a header or a footer.
+    /// </summary>
+    /// <param name="left">The text to display on the left side. Supports special placeholders like [page].</param>
+    /// <param name="center">The text to display in the center. Supports special placeholders like [doctitle].</param>
+    /// <param name="right">The text to display on the right side. Supports special placeholders like [date].</param>
+    /// <param name="fontName">The font family to use for the text.</param>
+    /// <param name="fontSize">The font size (in points) to use for the text.</param>
+    /// <param name="marginLeft">The left margin of the page (in inches), used as padding for the template.</param>
+    /// <param name="marginRight">The right margin of the page (in inches), used as padding for the template.</param>
+    /// <returns>An HTML string for the header/footer template, or <c>null</c> if all text sections are empty.</returns>
     private static string? BuildTemplate(string? left, string? center, string? right, string? fontName, double? fontSize, double marginLeft, double marginRight)
     {
-        if(string.IsNullOrEmpty(left) && string.IsNullOrEmpty(center) && string.IsNullOrEmpty(right))
+        if (string.IsNullOrEmpty(left) && string.IsNullOrEmpty(center) && string.IsNullOrEmpty(right))
         {
             return null;
         }

--- a/ChromiumHtmlToPdfConsole/Program.cs
+++ b/ChromiumHtmlToPdfConsole/Program.cs
@@ -234,7 +234,7 @@ static class Program
         }
         else
         {
-            var builtTemplate = BuildTemplate(options.HeaderLeft, options.HeaderCenter, options.HeaderRight, options.HeaderFontName, options.HeaderFontSize);
+            var builtTemplate = BuildTemplate(options.HeaderLeft, options.HeaderCenter, options.HeaderRight, options.HeaderFontName, options.HeaderFontSize, options.MarginLeft, options.MarginRight);
             if (builtTemplate != null)
             {
                 pageSettings.HeaderTemplate = builtTemplate;
@@ -251,7 +251,7 @@ static class Program
         }
         else
         {
-            var builtTemplate = BuildTemplate(options.FooterLeft, options.FooterCenter, options.FooterRight, options.FooterFontName, options.FooterFontSize);
+            var builtTemplate = BuildTemplate(options.FooterLeft, options.FooterCenter, options.FooterRight, options.FooterFontName, options.FooterFontSize, options.MarginLeft, options.MarginRight);
             if (builtTemplate != null)
             {
                 pageSettings.FooterTemplate = builtTemplate;
@@ -267,14 +267,15 @@ static class Program
     #endregion
 
     #region BuildTemplate
-    private static string? BuildTemplate(string? left, string? center, string? right, string? fontName, double? fontSize)
+    private static string? BuildTemplate(string? left, string? center, string? right, string? fontName, double? fontSize, double marginLeft, double marginRight)
     {
         if(string.IsNullOrEmpty(left) && string.IsNullOrEmpty(center) && string.IsNullOrEmpty(right))
         {
             return null;
         }
 
-        var style = new StringBuilder();
+        var style = new StringBuilder($"width: 100%; box-sizing: border-box; padding-left: {marginLeft}in; padding-right: {marginRight}in;");
+
         if (!string.IsNullOrEmpty(fontName))
         {
             style.Append($"font-family: {fontName}; ");

--- a/ChromiumHtmlToPdfConsole/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/ChromiumHtmlToPdfConsole/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net8.0\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This adds a full set of new options to control PDF headers and footers.

New options added:

**For the Header:**
•  --header-left, --header-center, --header-right
•  --header-font-name, --header-font-size

**For the Footer:**
• --footer-left, --footer-center, --footer-right
• --footer-font-name, --footer-font-size

**For Advanced Control:**
• --header-template and --footer-template for full customization with your own HTML.
_Note: The template options will override the simple text options if used._